### PR TITLE
Add trailing slash to links in readme to hub

### DIFF
--- a/excel-to-work-item/README.md
+++ b/excel-to-work-item/README.md
@@ -63,7 +63,7 @@ Robocode Lab will take care of setting up the environment for you, so you do not
 
 You can choose to run the activity in Robocode Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
 
-> For more information about running your activities in Robocode Lab, check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab).
+> For more information about running your activities in Robocode Lab, check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab/).
 
 ### Running with Activity Run
 
@@ -78,7 +78,7 @@ Press `Ctrl+Shift+Enter` (Windows) or `Shift-Command-Enter` (macOS) and click Re
 
 > You can also find the run command from the menu on the top of Robocode Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
 
-> In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab) for more information.
+> In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab/) for more information.
 
 ## Expected results of the activity
 

--- a/google-image-search/README.md
+++ b/google-image-search/README.md
@@ -40,7 +40,7 @@ Robocode Lab will take care of setting up the environment for you, so you do not
 
 You can choose to run the activity in Robocode Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
 
-> For more information about running your activities in Robocode Lab, check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab).
+> For more information about running your activities in Robocode Lab, check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab/).
 
 ### Running with Activity Run
 
@@ -55,4 +55,4 @@ Press `Ctrl+Shift+Enter` (Windows) or `Shift-Command-Enter` (macOS) and click Re
 
 > You can also find the run command from the menu on the top of Robocode Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
 
-> In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab) for more information.
+> In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab/) for more information.

--- a/simple-web-scraper/README.md
+++ b/simple-web-scraper/README.md
@@ -42,7 +42,7 @@ Robocode Lab will take care of setting up the environment for you, so you do not
 
 You can choose to run the activity in Robocode Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
 
-> For more information about running your activities in Robocode Lab, check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab).
+> For more information about running your activities in Robocode Lab, check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab/).
 
 ### Running with Activity Run
 
@@ -57,4 +57,4 @@ Press `Ctrl+Shift+Enter` (Windows) or `Shift-Command-Enter` (macOS) and click Re
 
 > You can also find the run command from the menu on the top of Robocode Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
 
-> In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab) for more information.
+> In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab/) for more information.

--- a/web-store-order-processor/README.md
+++ b/web-store-order-processor/README.md
@@ -75,7 +75,7 @@ Robocode Lab will take care of setting up the environment for you, so you do not
 
 You can choose to run the activity in Robocode Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
 
-> For more information about running your activities in Robocode Lab, check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab).
+> For more information about running your activities in Robocode Lab, check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab/).
 
 ### Running with Activity Run
 
@@ -90,4 +90,4 @@ Press `Ctrl+Shift+Enter` (Windows) or `Shift-Command-Enter` (macOS) and click Re
 
 > You can also find the run command from the menu on the top of Robocode Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
 
-> In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab) for more information.
+> In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab/) for more information.

--- a/work-item-to-pdf/README.md
+++ b/work-item-to-pdf/README.md
@@ -61,7 +61,7 @@ Robocode Lab will take care of setting up the environment for you, so you do not
 
 You can choose to run the activity in Robocode Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
 
-> For more information about running your activities in Robocode Lab, check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab).
+> For more information about running your activities in Robocode Lab, check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab/).
 
 ### Running with Activity Run
 
@@ -76,7 +76,7 @@ Press `Ctrl+Shift+Enter` (Windows) or `Shift-Command-Enter` (macOS) and click Re
 
 > You can also find the run command from the menu on the top of Robocode Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
 
-> In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab) for more information.
+> In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/development/robocode-documentation/running-robots-in-robocode-lab/) for more information.
 
 ## Expected results of the activity
 


### PR DESCRIPTION
Our links to the article on the hub that talks about how to run the activities in lab were missing the final slash `/`,  so they were broken.
