### PR TITLE
RPA Framework Tables library interface change

### DIFF
--- a/excel-to-work-item/config/conda.yaml
+++ b/excel-to-work-item/config/conda.yaml
@@ -6,4 +6,4 @@ dependencies:
   - pip
   - robotframework=3.1
   - pip:
-      - rpa-framework==0.8.7
+      - rpa-framework==0.9.0

--- a/excel-to-work-item/resources/keywords.robot
+++ b/excel-to-work-item/resources/keywords.robot
@@ -3,38 +3,21 @@ Library     Collections
 Library     OperatingSystem
 Library     RPA.Excel.Files
 Library     RPA.Robocloud.Items
-Library     RPA.Tables
 Variables   variables.py
 
 *** Keywords ***
 Store invitations in work item
-    Set up and validate
+    Set Up And Validate
     ${invitations}=   Collect invitations from the Excel file
     Load Work Item From Environment
     Set Work Item Variables   invitations=${invitations}
     Save Work Item
-    [Teardown]
 
-Set up and validate
+Set Up And Validate
     File Should Exist   ${EXCEL_FILE_PATH}
 
 Collect invitations from the Excel file
-    Open Workbook           ${EXCEL_FILE_PATH}
-    ${worksheet}=           Read Worksheet  header=${TRUE}
-    ${invitations_table}=   Create Table    ${worksheet}
-    ${invitations}=         Create List
-
-    FOR   ${row}  IN  @{invitations_table}
-        ${invitation}=      Create Dictionary
-        Set To Dictionary   ${invitation}   first_name  ${row.first_name}
-        Set To Dictionary   ${invitation}   last_name   ${row.last_name}
-        Set To Dictionary   ${invitation}   address     ${row.address}
-        Set To Dictionary   ${invitation}   city        ${row.city}
-        Set To Dictionary   ${invitation}   date        ${row.date}
-        Set To Dictionary   ${invitation}   time        ${row.time}
-
-        Append To List      ${invitations}  ${invitation}
-    END
-
+    Open Workbook      ${EXCEL_FILE_PATH}
+    ${invitations}=    Read Worksheet    header=${TRUE}
     Close Workbook
     [Return]  ${invitations}

--- a/google-image-search/config/conda.yaml
+++ b/google-image-search/config/conda.yaml
@@ -7,4 +7,4 @@ dependencies:
   - robotframework=3.1
   - robotframework-seleniumlibrary
   - pip:
-      - rpa-framework==0.8.7
+      - rpa-framework==0.9.0

--- a/rpa-form-challenge/config/conda.yaml
+++ b/rpa-form-challenge/config/conda.yaml
@@ -7,4 +7,4 @@ dependencies:
   - robotframework=3.1
   - robotframework-seleniumlibrary
   - pip:
-      - rpa-framework==0.8.7
+      - rpa-framework==0.9.0

--- a/rpa-form-challenge/resources/keywords.robot
+++ b/rpa-form-challenge/resources/keywords.robot
@@ -19,13 +19,13 @@ Open The Challenge Website
 
 Fill And Submit The Form With Data From
     [Arguments]    ${row}
-    Input Text    xpath://input[@ng-reflect-name="labelEmail"]    ${row.Email}
-    Input Text    xpath://input[@ng-reflect-name="labelPhone"]    ${row.Phone_Number}
-    Input Text    xpath://input[@ng-reflect-name="labelFirstName"]    ${row.First_Name}
-    Input Text    xpath://input[@ng-reflect-name="labelRole"]    ${row.Role_in_Company}
-    Input Text    xpath://input[@ng-reflect-name="labelAddress"]    ${row.Address}
-    Input Text    xpath://input[@ng-reflect-name="labelCompanyName"]    ${row.Company_Name}
-    Input Text    xpath://input[@ng-reflect-name="labelLastName"]    ${row.Last_Name}
+    Input Text    xpath://input[@ng-reflect-name="labelFirstName"]    ${row}[First Name]
+    Input Text    xpath://input[@ng-reflect-name="labelLastName"]     ${row}[Last Name]
+    Input Text    xpath://input[@ng-reflect-name="labelEmail"]        ${row}[Email]
+    Input Text    xpath://input[@ng-reflect-name="labelPhone"]        ${row}[Phone Number]
+    Input Text    xpath://input[@ng-reflect-name="labelAddress"]      ${row}[Address]
+    Input Text    xpath://input[@ng-reflect-name="labelCompanyName"]  ${row}[Company Name]
+    Input Text    xpath://input[@ng-reflect-name="labelRole"]         ${row}[Role in Company]
     Click Button    Submit
 
 Take A Screenshot Of The Results

--- a/simple-web-scraper/config/conda.yaml
+++ b/simple-web-scraper/config/conda.yaml
@@ -7,4 +7,4 @@ dependencies:
   - robotframework=3.1
   - robotframework-seleniumlibrary
   - pip:
-      - rpa-framework==0.8.7
+      - rpa-framework==0.9.0

--- a/web-store-order-processor/config/conda.yaml
+++ b/web-store-order-processor/config/conda.yaml
@@ -7,4 +7,4 @@ dependencies:
   - robotframework=3.1
   - robotframework-seleniumlibrary
   - pip:
-      - rpa-framework==0.8.7
+      - rpa-framework==0.9.0

--- a/web-store-order-processor/libraries/Orders.py
+++ b/web-store-order-processor/libraries/Orders.py
@@ -7,16 +7,20 @@ class Orders:
         files = Files()
         workbook = files.open_workbook(excel)
         rows = workbook.read_worksheet(header=True)
+
         tables = Tables()
         table = tables.create_table(rows)
         tables.filter_empty_rows(table)
+
         orders = []
         for row in table:
+            first_name, last_name = row["Name"].split()
             order = {
-                "item": row.Item,
-                "zip": int(row.Zip),
-                "first_name": row[0].split()[0],
-                "last_name": row[0].split()[1]
+                "item": row["Item"],
+                "zip": row["Zip"],
+                "first_name": first_name,
+                "last_name": last_name
             }
             orders.append(order)
+
         return orders

--- a/work-item-to-pdf/config/conda.yaml
+++ b/work-item-to-pdf/config/conda.yaml
@@ -6,5 +6,5 @@ dependencies:
   - pip
   - robotframework=3.1
   - pip:
-      - rpa-framework==0.8.7
+      - rpa-framework==0.9.0
       - robotframework-archivelibrary==0.4.0


### PR DESCRIPTION
rpa-framework 0.9.0 introduces a backwards compatibility break in Tables library and how it is iterated.

Previously FOR looping by default returned rows as namedtuples, but now this has been changed to dictionaries. Previous interface is still available in the Table instance through iter_tuples() method. This also affects how the values inside the rows are accessed.

This change was implemented because namedtuples require that properties, i.e. column names, need to be valid Python identifiers and can't contain certain characters or whitespace. This made mapping the data back to the source unnecessarily complicated.

Good example of dictionary row access in the RPA challenge keywords.