### PR TITLE
Fix missing int() conversion

### DIFF
--- a/web-store-order-processor/libraries/Orders.py
+++ b/web-store-order-processor/libraries/Orders.py
@@ -17,7 +17,7 @@ class Orders:
             first_name, last_name = row["Name"].split()
             order = {
                 "item": row["Item"],
-                "zip": row["Zip"],
+                "zip": int(row["Zip"]),
                 "first_name": first_name,
                 "last_name": last_name
             }


### PR DESCRIPTION
Removed necessary int() call by accident. Excel has them as floats which results in a Selenium error later when trying to input as text.