### PR TITLE
Package yamls and updates

### DIFF
--- a/excel-to-work-item/config/conda.yaml
+++ b/excel-to-work-item/config/conda.yaml
@@ -5,4 +5,4 @@ dependencies:
   - python=3.7.5
   - pip=20.1
   - pip:
-      - rpa-framework==0.9.3
+    - rpa-framework==0.10.*

--- a/excel-to-work-item/entrypoints/entrypoint.cmd
+++ b/excel-to-work-item/entrypoints/entrypoint.cmd
@@ -2,7 +2,7 @@
 
 REM Executes all tasks defined in the "tasks" directory.
 REM Writes log and report files to "output" directory.
-robot -d output --logtitle "Task log" tasks || goto :error
+python -m robot -d output --logtitle "Task log" tasks || goto :error
 
 echo Success
 goto :EOF

--- a/excel-to-work-item/entrypoints/entrypoint.sh
+++ b/excel-to-work-item/entrypoints/entrypoint.sh
@@ -2,4 +2,4 @@
 
 # Executes all tasks defined in the "tasks" directory.
 # Writes log and report files to "output" directory.
-robot -d output --logtitle "Task log" tasks/
+python -m robot -d output --logtitle "Task log" tasks/

--- a/excel-to-work-item/package.yaml
+++ b/excel-to-work-item/package.yaml
@@ -1,0 +1,22 @@
+activities:
+  excel-to-work-item:
+    output: output
+    activityRoot: .
+    environment:
+      path:
+        - bin
+      pythonPath:
+        - variables
+        - libraries
+        - resources
+    action:
+      command:
+        - python
+        - -m
+        - robot
+        - -d
+        - output
+        - --logtitle
+        - Task log
+        - ./tasks/*.robot
+condaConfig: config/conda.yaml

--- a/google-image-search/config/conda.yaml
+++ b/google-image-search/config/conda.yaml
@@ -5,4 +5,4 @@ dependencies:
   - python=3.7.5
   - pip=20.1
   - pip:
-      - rpa-framework==0.9.3
+    - rpa-framework==0.10.*

--- a/google-image-search/entrypoints/entrypoint.cmd
+++ b/google-image-search/entrypoints/entrypoint.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-robot -d output --logtitle "Task log" tasks || goto :error
+python -m robot -d output --logtitle "Task log" tasks || goto :error
 
 echo Success
 goto :EOF

--- a/google-image-search/entrypoints/entrypoint.sh
+++ b/google-image-search/entrypoints/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-robot -d output --logtitle "Task log" tasks/
+python -m robot -d output --logtitle "Task log" tasks/

--- a/google-image-search/package.yaml
+++ b/google-image-search/package.yaml
@@ -1,0 +1,22 @@
+activities:
+  Image search:
+    output: output
+    activityRoot: .
+    environment:
+      path:
+        - bin
+      pythonPath:
+        - variables
+        - libraries
+        - resources
+    action:
+      command:
+        - python
+        - -m
+        - robot
+        - -d
+        - output
+        - --logtitle
+        - Task log
+        - ./tasks/*.robot
+condaConfig: config/conda.yaml

--- a/robotsparebin-complete/config/conda.yaml
+++ b/robotsparebin-complete/config/conda.yaml
@@ -5,4 +5,4 @@ dependencies:
   - python=3.7.5
   - pip=20.1
   - pip:
-      - rpa-framework==0.9.3
+    - rpa-framework==0.10.*

--- a/robotsparebin-complete/entrypoints/entrypoint.cmd
+++ b/robotsparebin-complete/entrypoints/entrypoint.cmd
@@ -2,7 +2,7 @@
 
 REM Executes all tasks defined in the "tasks" directory.
 REM Writes log and report files to "output" directory.
-robot -d output --logtitle "Task log" tasks || goto :error
+python -m robot -d output --logtitle "Task log" tasks || goto :error
 
 echo Success
 goto :EOF

--- a/robotsparebin-complete/entrypoints/entrypoint.sh
+++ b/robotsparebin-complete/entrypoints/entrypoint.sh
@@ -2,4 +2,4 @@
 
 # Executes all tasks defined in the "tasks" directory.
 # Writes log and report files to "output" directory.
-robot -d output --logtitle "Task log" tasks/
+python -m robot -d output --logtitle "Task log" tasks/

--- a/robotsparebin-complete/package.yaml
+++ b/robotsparebin-complete/package.yaml
@@ -1,0 +1,15 @@
+activities:
+  RobotSpareBin Complete:
+    output: output
+    activityRoot: .
+    action:
+      command:
+        - python
+        - -m
+        - robot
+        - -d
+        - output
+        - --logtitle
+        - Task log
+        - ./tasks/*.robot
+condaConfig: config/conda.yaml

--- a/robotsparebin-starter/config/conda.yaml
+++ b/robotsparebin-starter/config/conda.yaml
@@ -5,4 +5,4 @@ dependencies:
   - python=3.7.5
   - pip=20.1
   - pip:
-      - rpa-framework==0.9.3
+    - rpa-framework==0.10.*

--- a/robotsparebin-starter/entrypoints/entrypoint.cmd
+++ b/robotsparebin-starter/entrypoints/entrypoint.cmd
@@ -2,7 +2,7 @@
 
 REM Executes all tasks defined in the "tasks" directory.
 REM Writes log and report files to "output" directory.
-robot -d output --logtitle "Task log" tasks || goto :error
+python -m robot -d output --logtitle "Task log" tasks || goto :error
 
 echo Success
 goto :EOF

--- a/robotsparebin-starter/entrypoints/entrypoint.sh
+++ b/robotsparebin-starter/entrypoints/entrypoint.sh
@@ -2,4 +2,4 @@
 
 # Executes all tasks defined in the "tasks" directory.
 # Writes log and report files to "output" directory.
-robot -d output --logtitle "Task log" tasks/
+python -m robot -d output --logtitle "Task log" tasks/

--- a/robotsparebin-starter/package.yaml
+++ b/robotsparebin-starter/package.yaml
@@ -1,0 +1,15 @@
+activities:
+  RobotSpareBin Starter:
+    output: output
+    activityRoot: .
+    action:
+      command:
+        - python
+        - -m
+        - robot
+        - -d
+        - output
+        - --logtitle
+        - Task log
+        - ./tasks/*.robot
+condaConfig: config/conda.yaml

--- a/rpa-form-challenge/config/conda.yaml
+++ b/rpa-form-challenge/config/conda.yaml
@@ -5,4 +5,4 @@ dependencies:
   - python=3.7.5
   - pip=20.1
   - pip:
-      - rpa-framework==0.9.3
+    - rpa-framework==0.10.*

--- a/rpa-form-challenge/entrypoints/entrypoint.cmd
+++ b/rpa-form-challenge/entrypoints/entrypoint.cmd
@@ -2,7 +2,7 @@
 
 REM Executes all tasks defined in the "tasks" directory.
 REM Writes log and report files to "output" directory.
-robot -d output --logtitle "Task log" tasks || goto :error
+python -m robot -d output --logtitle "Task log" tasks || goto :error
 
 echo Success
 goto :EOF

--- a/rpa-form-challenge/entrypoints/entrypoint.sh
+++ b/rpa-form-challenge/entrypoints/entrypoint.sh
@@ -2,4 +2,4 @@
 
 # Executes all tasks defined in the "tasks" directory.
 # Writes log and report files to "output" directory.
-robot -d output --logtitle "Task log" tasks/
+python -m robot -d output --logtitle "Task log" tasks/

--- a/rpa-form-challenge/package.yaml
+++ b/rpa-form-challenge/package.yaml
@@ -1,0 +1,15 @@
+activities:
+  Challenge:
+    output: output
+    activityRoot: .
+    action:
+      command:
+        - python
+        - -m
+        - robot
+        - -d
+        - output
+        - --logtitle
+        - Task log
+        - ./tasks/*.robot
+condaConfig: config/conda.yaml

--- a/simple-web-scraper/config/conda.yaml
+++ b/simple-web-scraper/config/conda.yaml
@@ -5,4 +5,4 @@ dependencies:
   - python=3.7.5
   - pip=20.1
   - pip:
-      - rpa-framework==0.9.3
+    - rpa-framework==0.10.*

--- a/simple-web-scraper/entrypoints/entrypoint.cmd
+++ b/simple-web-scraper/entrypoints/entrypoint.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-robot -d output --logtitle "Task log" tasks || goto :error
+python -m robot -d output --logtitle "Task log" tasks || goto :error
 
 echo Success
 goto :EOF

--- a/simple-web-scraper/entrypoints/entrypoint.sh
+++ b/simple-web-scraper/entrypoints/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-robot -d output --logtitle "Task log" tasks/
+python -m robot -d output --logtitle "Task log" tasks/

--- a/simple-web-scraper/package.yaml
+++ b/simple-web-scraper/package.yaml
@@ -1,0 +1,20 @@
+activities:
+  Web scraper:
+    output: output
+    activityRoot: .
+    environment:
+      pythonPath:
+        - variables
+        - libraries
+        - resources
+    action:
+      command:
+        - python
+        - -m
+        - robot
+        - -d
+        - output
+        - --logtitle
+        - Task log
+        - ./tasks/*.robot
+condaConfig: config/conda.yaml

--- a/web-store-order-processor/config/conda.yaml
+++ b/web-store-order-processor/config/conda.yaml
@@ -5,4 +5,4 @@ dependencies:
   - python=3.7.5
   - pip=20.1
   - pip:
-      - rpa-framework==0.9.3
+    - rpa-framework==0.10.*

--- a/web-store-order-processor/entrypoints/entrypoint.cmd
+++ b/web-store-order-processor/entrypoints/entrypoint.cmd
@@ -1,6 +1,6 @@
 @echo off
 
-robot -d output --logtitle "Task log" tasks || goto :error
+python -m robot -d output --logtitle "Task log" tasks || goto :error
 
 echo Success
 goto :EOF

--- a/web-store-order-processor/entrypoints/entrypoint.sh
+++ b/web-store-order-processor/entrypoints/entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash -ex
 
-robot -d output --logtitle "Task log" tasks/
+python -m robot -d output --logtitle "Task log" tasks/

--- a/web-store-order-processor/package.yaml
+++ b/web-store-order-processor/package.yaml
@@ -1,0 +1,22 @@
+activities:
+  Web store orders:
+    output: output
+    activityRoot: .
+    environment:
+      path:
+        - bin
+      pythonPath:
+        - variables
+        - libraries
+        - resources
+    action:
+      command:
+        - python
+        - -m
+        - robot
+        - -d
+        - output
+        - --logtitle
+        - Task log
+        - ./tasks/*.robot
+condaConfig: config/conda.yaml

--- a/work-item-to-pdf/config/conda.yaml
+++ b/work-item-to-pdf/config/conda.yaml
@@ -5,5 +5,5 @@ dependencies:
   - python=3.7.5
   - pip=20.1
   - pip:
-      - rpa-framework==0.9.3
-      - robotframework-archivelibrary==0.4.0
+    - rpa-framework==0.10.*
+    - robotframework-archivelibrary==0.4.0

--- a/work-item-to-pdf/entrypoints/entrypoint.cmd
+++ b/work-item-to-pdf/entrypoints/entrypoint.cmd
@@ -2,7 +2,7 @@
 
 REM Executes all tasks defined in the "tasks" directory.
 REM Writes log and report files to "output" directory.
-robot -d output --logtitle "Task log" tasks || goto :error
+python -m robot -d output --logtitle "Task log" tasks || goto :error
 
 echo Success
 goto :EOF

--- a/work-item-to-pdf/entrypoints/entrypoint.sh
+++ b/work-item-to-pdf/entrypoints/entrypoint.sh
@@ -2,4 +2,4 @@
 
 # Executes all tasks defined in the "tasks" directory.
 # Writes log and report files to "output" directory.
-robot -d output --logtitle "Task log" tasks/
+python -m robot -d output --logtitle "Task log" tasks/

--- a/work-item-to-pdf/package.yaml
+++ b/work-item-to-pdf/package.yaml
@@ -1,0 +1,22 @@
+activities:
+  work-item-to-pdf:
+    output: output
+    activityRoot: .
+    environment:
+      path:
+        - bin
+      pythonPath:
+        - variables
+        - libraries
+        - resources
+    action:
+      command:
+        - python
+        - -m
+        - robot
+        - -d
+        - output
+        - --logtitle
+        - Task log
+        - ./tasks/*.robot
+condaConfig: config/conda.yaml


### PR DESCRIPTION
Added package.yaml for each example
Updated conda.yamls for all examples
Fixed entrypoints script to have 'python -m'
NOTE: Entrypoint scripts are going away as soon as the package.yaml support is fully implemented in Lab.. but this is for the switch over period.

NOTE: Merge should be synced with worker and package.yaml related content.