### PR TITLE
Fix path of the generated PDF in robotsparebin-complete

### DIFF
--- a/robotsparebin-complete/tasks/robot.robot
+++ b/robotsparebin-complete/tasks/robot.robot
@@ -49,11 +49,11 @@ Export The Table As A PDF
     Wait Until Element Is Visible    id:sales-results
     ${sales_results_html}=    Get Element Attribute    id:sales-results    outerHTML
     Create File    sales_results.template    ${sales_results_html}    overwrite=True
-    Template Html To Pdf    sales_results.template    sales_results.pdf
+    Template Html To Pdf    sales_results.template    ${CURDIR}${/}..${/}output${/}sales_results.pdf
 
 *** Keywords ***
 Log Out And Close The Browser
-    Click Button    Log out
+    Click button    Log out
     Close Browser
 
 *** Tasks ***

--- a/robotsparebin-complete/tasks/robot.robot
+++ b/robotsparebin-complete/tasks/robot.robot
@@ -53,7 +53,7 @@ Export The Table As A PDF
 
 *** Keywords ***
 Log Out And Close The Browser
-    Click button    Log out
+    Click Button    Log out
     Close Browser
 
 *** Tasks ***


### PR DESCRIPTION
 so that it shows up in artefacts, and also works locally.

Originates from this slack discussion: 

https://robocorptechnologies.slack.com/archives/CQS4NNPGV/p1590671250066000

In the future changes in the kernel should allow us to have a less messy solution.