### PR TITLE
Added code comments in activities that need additional setup to run locally

### DIFF
--- a/excel-to-work-item/tasks/robot.robot
+++ b/excel-to-work-item/tasks/robot.robot
@@ -1,3 +1,4 @@
+## To run this code locally, you need to complete additional setup steps. Check the README.md file for details!
 *** Settings ***
 Documentation     Excel reader robot. Reads information from a given Excel file and
 ...               adds it to the work item.

--- a/web-store-order-processor/tasks/web-store-order-processor.robot
+++ b/web-store-order-processor/tasks/web-store-order-processor.robot
@@ -1,3 +1,4 @@
+## To run this code locally, you need to complete additional setup steps. Check the README.md file for details!
 *** Settings ***
 Documentation     Swag order robot. Places orders at https://www.saucedemo.com/
 ...               by processing a spreadsheet of orders and ordering the

--- a/work-item-to-pdf/tasks/robot.robot
+++ b/work-item-to-pdf/tasks/robot.robot
@@ -1,3 +1,4 @@
+## To run this code locally, you need to complete additional setup steps. Check the README.md file for details!
 *** Settings ***
 Documentation     Invite printer robot. Creates PDF invitations to events based on data it receives
 ...               from the work item.


### PR DESCRIPTION
Some of the activities will not run locally unless you complete the setup steps detailed in the README file. This adds a code comment alerting the user about it.

![image](https://user-images.githubusercontent.com/185412/86344303-cbc93700-bc62-11ea-9cc1-9c403a2c75bd.png)
