### PR TITLE
Remove calls to the Load Work Item From Environment keyword

### DIFF
--- a/excel-to-work-item/resources/keywords.robot
+++ b/excel-to-work-item/resources/keywords.robot
@@ -8,7 +8,6 @@ Variables         variables.py
 Store invitations in work item
     Set Up And Validate
     ${invitations}=    Collect invitations from the Excel file
-    Load Work Item From Environment
     Set Work Item Variables    invitations=${invitations}
     Save Work Item
 

--- a/work-item-to-pdf/resources/keywords.robot
+++ b/work-item-to-pdf/resources/keywords.robot
@@ -20,7 +20,6 @@ Set up and validate
     Create Directory    ${PDF_TEMP_OUTPUT_DIRECTORY}
 
 Collect invitations from work item
-    Load Work Item From Environment
     ${invitations}=    Get Work Item Variable    invitations
     [Return]    ${invitations}
 


### PR DESCRIPTION
The library calls this functionality automatically based on environment variables, so no need to call it directly, causing a double call.