### PR TITLE
LEA-488: Use plural section headings everywhere for consistency and for default auto-completion match

### DIFF
--- a/excel-to-work-item/resources/keywords.robot
+++ b/excel-to-work-item/resources/keywords.robot
@@ -11,9 +11,11 @@ Store invitations in work item
     Set Work Item Variables    invitations=${invitations}
     Save Work Item
 
+*** Keywords ***
 Set Up And Validate
     File Should Exist    ${EXCEL_FILE_PATH}
 
+*** Keywords ***
 Collect invitations from the Excel file
     Open Workbook    ${EXCEL_FILE_PATH}
     ${invitations}=    Read Worksheet    header=True

--- a/google-image-search/tasks/google-image-search.robot
+++ b/google-image-search/tasks/google-image-search.robot
@@ -6,26 +6,26 @@ Library           RPA.Browser
 ${GOOGLE_URL}     https://google.com/?hl=en
 ${SEARCH_TERM}    cute cat picture
 
-*** Keyword ***
+*** Keywords ***
 Open Google search page
     Open Available Browser    ${GOOGLE_URL}
 
-*** Keyword ***
+*** Keywords ***
 Search for
     [Arguments]    ${text}
     Input Text    name:q    ${text}
     Press Keys    name:q    ENTER
     Wait Until Page Contains    results
 
-*** Keyword ***
+*** Keywords ***
 View image search results
     Click Link    Images
 
-*** Keyword ***
+*** Keywords ***
 Screenshot first result
     Capture Element Screenshot    css:div[data-ri="0"]
 
-*** Task ***
+*** Tasks ***
 Execute Google image search and store the first result image
     Open Google search page
     Search for    ${SEARCH_TERM}

--- a/rpa-form-challenge/tasks/robot.robot
+++ b/rpa-form-challenge/tasks/robot.robot
@@ -6,20 +6,20 @@ Library           RPA.Browser
 Library           RPA.Excel.Files
 Library           RPA.HTTP
 
-*** Keyword ***
+*** Keywords ***
 Get The List Of People From The Excel File
     Open Workbook    challenge.xlsx
     ${table}=    Read Worksheet As Table    header=True
     Close Workbook
     [Return]    ${table}
 
-*** Keyword ***
+*** Keywords ***
 Set Value By Xpath
     [Arguments]    ${xpath}    ${value}
     ${result}=    Execute Javascript    document.evaluate('${xpath}',document.body,null,9,null).singleNodeValue.value='${value}';
     [Return]    ${result}
 
-*** Keyword ***
+*** Keywords ***
 Fill And Submit The Form
     [Arguments]    ${person}
     Set Value By Xpath    //input[@ng-reflect-name="labelFirstName"]    ${person}[First Name]
@@ -31,20 +31,20 @@ Fill And Submit The Form
     Set Value By Xpath    //input[@ng-reflect-name="labelPhone"]    ${person}[Phone Number]
     Click Button    Submit
 
-*** Task ***
+*** Tasks ***
 Start The Challenge
     Open Available Browser    http://rpachallenge.com/
     Download    http://rpachallenge.com/assets/downloadFiles/challenge.xlsx    overwrite=True
     Click Button    Start
 
-*** Task ***
+*** Tasks ***
 Fill The Forms
     ${people}=    Get The List Of People From The Excel File
     FOR    ${person}    IN    @{people}
         Fill And Submit The Form    ${person}
     END
 
-*** Task ***
+*** Tasks ***
 Collect The Results
     Capture Element Screenshot    css:div.congratulations
     Close All Browsers

--- a/simple-web-scraper/resources/keywords.robot
+++ b/simple-web-scraper/resources/keywords.robot
@@ -4,7 +4,7 @@ Library           OperatingSystem
 Library           RPA.Browser
 Variables         variables.py
 
-*** Keyword ***
+*** Keywords ***
 Store web page content
     ${current_date}=    Current date
     Log    ${current_date}

--- a/web-store-order-processor/resources/keywords.robot
+++ b/web-store-order-processor/resources/keywords.robot
@@ -4,7 +4,7 @@ Library           Orders
 Library           RPA.Browser
 Variables         variables.py
 
-*** Keyword ***
+*** Keywords ***
 Process orders
     Validate prerequisites
     Open Swag Labs
@@ -15,7 +15,7 @@ Process orders
     END
     [Teardown]    Close Browser
 
-*** Keyword ***
+*** Keywords ***
 Validate prerequisites
     File Should Exist    ${EXCEL_FILE_PATH}
     Variable Should Exist    ${SWAG_LABS_USER_NAME}
@@ -23,11 +23,11 @@ Validate prerequisites
     Variable Should Exist    ${SWAG_LABS_PASSWORD}
     Should Not Be Empty    ${SWAG_LABS_PASSWORD}
 
-*** Keyword ***
+*** Keywords ***
 Open Swag Labs
     Open Available Browser    ${SWAG_LABS_URL}
 
-*** Keyword ***
+*** Keywords ***
 Login
     [Arguments]    ${user_name}    ${password}
     Input Text    user-name    ${user_name}
@@ -35,17 +35,17 @@ Login
     Submit Form
     Assert logged in
 
-*** Keyword ***
+*** Keywords ***
 Assert logged in
     Wait Until Page Contains Element    inventory_container
     Location Should Be    ${SWAG_LABS_URL}/inventory.html
 
-*** Keyword ***
+*** Keywords ***
 Collect orders
     ${orders}=    Get orders    ${EXCEL_FILE_PATH}
     [Return]    ${orders}
 
-*** Keyword ***
+*** Keywords ***
 Process order
     [Arguments]    ${order}
     Reset application state
@@ -57,22 +57,22 @@ Process order
     Checkout    ${order}
     Open products page
 
-*** Keyword ***
+*** Keywords ***
 Reset application state
     Click Button    css:.bm-burger-button button
     Wait Until Element Is Visible    id:reset_sidebar_link
     Click Link    reset_sidebar_link
 
-*** Keyword ***
+*** Keywords ***
 Open products page
     Go To    ${SWAG_LABS_URL}/inventory.html
 
-*** Keyword ***
+*** Keywords ***
 Assert cart is empty
     Element Text Should Be    css:.shopping_cart_link    ${EMPTY}
     Page Should Not Contain Element    css:.shopping_cart_badge
 
-*** Keyword ***
+*** Keywords ***
 Add product to cart
     [Arguments]    ${order}
     ${product_name}=    Set Variable    ${order["item"]}
@@ -82,28 +82,28 @@ Add product to cart
     Click Button    ${add_to_cart_button}
     Assert items in cart    1
 
-*** Keyword ***
+*** Keywords ***
 Assert items in cart
     [Arguments]    ${quantity}
     Element Text Should Be    css:.shopping_cart_badge    ${quantity}
 
-*** Keyword ***
+*** Keywords ***
 Open cart
     Click Link    css:.shopping_cart_link
     Assert cart page
 
-*** Keyword ***
+*** Keywords ***
 Assert cart page
     Wait Until Page Contains Element    cart_contents_container
     Location Should Be    ${SWAG_LABS_URL}/cart.html
 
-*** Keyword ***
+*** Keywords ***
 Assert one product in cart
     [Arguments]    ${order}
     Element Text Should Be    css:.cart_quantity    1
     Element Text Should Be    css:.inventory_item_name    ${order["item"]}
 
-*** Keyword ***
+*** Keywords ***
 Checkout
     [Arguments]    ${order}
     Click Link    css:.checkout_button
@@ -117,17 +117,17 @@ Checkout
     Click Link    css:.btn_action
     Assert checkout complete page
 
-*** Keyword ***
+*** Keywords ***
 Assert checkout information page
     Wait Until Page Contains Element    checkout_info_container
     Location Should Be    ${SWAG_LABS_URL}/checkout-step-one.html
 
-*** Keyword ***
+*** Keywords ***
 Assert checkout confirmation page
     Wait Until Page Contains Element    checkout_summary_container
     Location Should Be    ${SWAG_LABS_URL}/checkout-step-two.html
 
-*** Keyword ***
+*** Keywords ***
 Assert checkout complete page
     Wait Until Page Contains Element    checkout_complete_container
     Location Should Be    ${SWAG_LABS_URL}/checkout-complete.html

--- a/work-item-to-pdf/resources/keywords.robot
+++ b/work-item-to-pdf/resources/keywords.robot
@@ -15,21 +15,26 @@ Process invitations
     Create ZIP package from PDF files
     [Teardown]    Cleanup temporary PDF directory
 
+*** Keywords ***
 Set up and validate
     File Should Exist    ${PDF_TEMPLATE_PATH}
     Create Directory    ${PDF_TEMP_OUTPUT_DIRECTORY}
 
+*** Keywords ***
 Collect invitations from work item
     ${invitations}=    Get Work Item Variable    invitations
     [Return]    ${invitations}
 
+*** Keywords ***
 Create PDF file for invitation
     [Arguments]    ${invitation}
     Template Html To Pdf    ${PDF_TEMPLATE_PATH}    ${PDF_TEMP_OUTPUT_DIRECTORY}/${invitation["first_name"]}_${invitation["last_name"]}.pdf    ${invitation}
 
+*** Keywords ***
 Create ZIP package from PDF files
     ${zip_file_name}=    Set Variable    ${OUTPUT_DIRECTORY}/PDFs.zip
     Create Zip From Files In Directory    ${PDF_TEMP_OUTPUT_DIRECTORY}    ${zip_file_name}
 
+*** Keywords ***
 Cleanup temporary PDF directory
     Remove Directory    ${PDF_TEMP_OUTPUT_DIRECTORY}    True


### PR DESCRIPTION
- Adds `*** Keywords ***` section heading for each keyword to make the examples view better in Robocode Lab (Lab works best when each keyword has the heading).

- Changes all singular (`Keyword`, `Task`) headings to plural for consistency, and because the plural is the default auto-completed form both in Lab and in LSP (and Lab will start using LSP in the future). The plurals look a bit weird, but at least now everything is consistent and matches what you get when auto-completing.