### PR TITLE
Re: LEA-491: Use Click Element When Visible keyword

### DIFF
--- a/web-store-order-processor/config/conda.yaml
+++ b/web-store-order-processor/config/conda.yaml
@@ -5,4 +5,4 @@ dependencies:
   - python=3.7.5
   - pip=20.1
   - pip:
-    - rpaframework==2.*
+      - rpaframework==2.5.1

--- a/web-store-order-processor/resources/keywords.robot
+++ b/web-store-order-processor/resources/keywords.robot
@@ -60,8 +60,7 @@ Process order
 *** Keywords ***
 Reset application state
     Click Button    css:.bm-burger-button button
-    Wait Until Element Is Visible    id:reset_sidebar_link
-    Click Link    reset_sidebar_link
+    Click Element When Visible    id:reset_sidebar_link
 
 *** Keywords ***
 Open products page
@@ -113,8 +112,7 @@ Checkout
     Input Text    postal-code    ${order["zip"]}
     Submit Form
     Assert checkout confirmation page
-    Wait Until Page Contains Element    css:.btn_action
-    Click Link    css:.btn_action
+    Click Element When Visible    css:.btn_action
     Assert checkout complete page
 
 *** Keywords ***


### PR DESCRIPTION
Updates web store order robot example activity:

- Require `rpaframework 2.5.1`
- Use `Click Element When Visible` keyword

Side effects (known):

Notebook run prints some overly long Excel output. However, we can not prevent people from seeing this forever (until it is fixed). Let's accept that an improvement is required.

The current `rpaframework` version is `2.5.1` and the oldest non-Notebook-printing version is `2.2.0`. That's already quite a gap.