### PR TITLE
Google search activity: show the screenshot in lab, allow to download the screenshot in cloud

### DIFF
--- a/google-image-search/tasks/google-image-search.robot
+++ b/google-image-search/tasks/google-image-search.robot
@@ -23,7 +23,7 @@ View image search results
 
 *** Keywords ***
 Screenshot first result
-    Capture Element Screenshot    css:div[data-ri="0"]
+    Capture Element Screenshot    css:div[data-ri="0"]    ${OUTPUT DIR}${/}screenshot.png
 
 *** Tasks ***
 Execute Google image search and store the first result image


### PR DESCRIPTION
By adding the path of the screenshot in the output dir, Robocode Lab still shows the screenshot in the notebook output, and running in cloud shows the screenshot in the artefacts listing:

![image](https://user-images.githubusercontent.com/185412/91967805-6655fd00-ed1c-11ea-80b2-9533290b6061.png)



If we merge this, we also need to make sure that the example activity in cloud is updated accordingly.
