### PR TITLE
Update product names in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 Each example activity directory contains a `README.md` that provides information regarding the activity.
 
-These example activities are included with [Robocode Lab](https://cloud.robocorp.com/private/download-robocode), and can be opened from the Robocode Lab launch screen.
+These example activities are included with [Robocorp Lab](https://robocorp.com/download/), and can be opened from the Robocorp Lab launch screen.
 
-Another way to run these activities is to use [Robocode CLI](https://pypi.org/project/robocode/).
+Another way to run these activities is to use [Robocorp CLI](https://pypi.org/project/robocode/).

--- a/excel-to-work-item/README.md
+++ b/excel-to-work-item/README.md
@@ -18,7 +18,7 @@ pip install rpaframework
 
 ## Setting up the Robocloud.Items library for local use
 
-When executing our robot in a cloud environment like [Robocloud](https://cloud.robocorp.com), the `RPA.Robocloud.Items` library will store the work item in the cloud environment, sharing its contents between activities defined in the same process, without any configuration needed.
+When executing our robot in a cloud environment like [Robocorp Cloud](https://cloud.robocorp.com), the `RPA.Robocloud.Items` library will store the work item in the cloud environment, sharing its contents between activities defined in the same process, without any configuration needed.
 
 When developing our activity and running it locally, however, we want the library to store the data in a JSON file, and provide the required parameters to simulate the cloud environment. You can learn more about the internals of the `RPA.Robocloud.Items` library [here](https://hub.robocorp.com/resources/libraries/rpaframework-Robocloud-Items/).
 
@@ -33,7 +33,7 @@ Paste this content into your `items.json` file, creating an empty but valid json
 Edit the `RPA_WORKITEMS_PATH` variable to point to the `items.json` file on your filesystem. On macOS / Linux, use normal file paths,
 for example, `/tmp/items.json`. On Windows 10, you need to escape the path, for example, `C:\\Users\\User\\items.json`.
 
-## Executing with Robocode CLI
+## Executing with Robocorp CLI
 
 > Assumes `robocode` is installed. Install with `pip install robocode`.
 
@@ -57,13 +57,13 @@ macOS / Linux:
 robo run entrypoint.sh -v devdata/env.json
 ```
 
-## Executing with Robocode Lab
+## Executing with Robocorp Lab
 
-Robocode Lab will take care of setting up the environment for you, so you do not need to run additional installation commands.
+Robocorp Lab will take care of setting up the environment for you, so you do not need to run additional installation commands.
 
-You can choose to run the activity in Robocode Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
+You can choose to run the activity in Robocorp Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
 
-> Visit Robohub to learn more about [running your activities in Robocode Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
+> Visit Robohub to learn more about [running your activities in Robocorp Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
 
 ### Running with Activity Run
 
@@ -76,7 +76,7 @@ Navigate to the `tasks` directory and double-click the `robot.robot` file to ope
 
 Click the `>>` icon or press `Ctrl+Shift+Enter` (Windows) or `Shift-Command-Enter` (macOS) and click `Restart` to run the robot.
 
-> You can also find the run command from the menu on the top of Robocode Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
+> You can also find the run command from the menu on the top of Robocorp Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
 
 > In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/) for more information.
 

--- a/excel-to-work-item/bin/INTRODUCTION.md
+++ b/excel-to-work-item/bin/INTRODUCTION.md
@@ -3,5 +3,5 @@
 If you need your package to have standalone binaries or executables, you
 should add them to this directory.
 
-This directory will be in PATH when the package is executed in Robocloud Worker
-or through Robocode CLI.
+This directory will be in PATH when the package is executed in Robocorp App
+or through Robocorp CLI.

--- a/excel-to-work-item/config/INTRODUCTION.md
+++ b/excel-to-work-item/config/INTRODUCTION.md
@@ -8,7 +8,7 @@ in a target environment.
 For a local environment, you can use `pip` or `conda` or another preferred
 package manager to install the dependencies. Keep the `conda.yaml` in sync with
 the required dependencies. Otherwise, the robot might work when run locally,
-but not when run using Robocloud Worker.
+but not when run using Robocorp App.
 
 If you do not want to use conda at all and want to provide the execution
 environment yourself, you can delete the `conda.yaml` file.

--- a/excel-to-work-item/devdata/INTRODUCTION.md
+++ b/excel-to-work-item/devdata/INTRODUCTION.md
@@ -2,11 +2,11 @@
 
 This directory should contain local development data.
 
-This data should not be used in actual Robocloud Worker run but can be
+This data should not be used in actual Robocorp App run but can be
 used when you are building and debugging your entrypoints and activities.
 
 ## What to put here?
 
 - Local work item data
 - Local environment variables (in JSON format)
-- Local custom data files (*.csv, etc.)
+- Local custom data files (\*.csv, etc.)

--- a/excel-to-work-item/entrypoints/INTRODUCTION.md
+++ b/excel-to-work-item/entrypoints/INTRODUCTION.md
@@ -5,7 +5,7 @@ Define each entrypoint here as a script
 - These are the scripts you select for activity in Robocloud
 - Entrypoint scripts should not use any arguments
   > It is better to create scripts to contain the different argument variations
-  > so that selecting an entrypoint in Robocloud remains clear
+  > so that selecting an entrypoint in Robocorp Cloud remains clear
 
-This directory will be in PATH when the package is executed in Robocloud Worker
-or through Robocode CLI.
+This directory will be in PATH when the package is executed in Robocorp App
+or through Robocorp CLI.

--- a/excel-to-work-item/temp/INTRODUCTION.md
+++ b/excel-to-work-item/temp/INTRODUCTION.md
@@ -6,4 +6,4 @@ included in the package. By default, this directory is in .gitignore file.
 Robocode local run uses this directory as a working directory by default.
 
 If you remove this directory from the activity directory structure, you must
-provide the `--workarea` argument to Robocode CLI run command.
+provide the `--workarea` argument to Robocorp CLI run command.

--- a/google-image-search/README.md
+++ b/google-image-search/README.md
@@ -10,7 +10,7 @@ Install Python package dependencies:
 pip install rpaframework
 ```
 
-## Executing with Robocode CLI
+## Executing with Robocorp CLI
 
 > Assumes `robocode` is installed. Install with `pip install robocode`.
 
@@ -34,13 +34,13 @@ macOS / Linux:
 robo run entrypoint.sh
 ```
 
-## Executing with Robocode Lab
+## Executing with Robocorp Lab
 
-Robocode Lab will take care of setting up the environment for you, so you do not need to run additional installation commands.
+Robocorp Lab will take care of setting up the environment for you, so you do not need to run additional installation commands.
 
-You can choose to run the activity in Robocode Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
+You can choose to run the activity in Robocorp Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
 
-> Visit Robohub to learn more about [running your activities in Robocode Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
+> Visit Robohub to learn more about [running your activities in Robocorp Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
 
 ### Running with Activity Run
 
@@ -53,6 +53,6 @@ Navigate to the `tasks` directory and double-click the `.robot` file to open it 
 
 Click the `>>` icon or press `Ctrl+Shift+Enter` (Windows) or `Shift-Command-Enter` (macOS) and click `Restart` to run the robot.
 
-> You can also find the run command from the menu on the top of Robocode Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
+> You can also find the run command from the menu on the top of Robocorp Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
 
 > In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/) for more information.

--- a/google-image-search/config/INTRODUCTION.md
+++ b/google-image-search/config/INTRODUCTION.md
@@ -8,7 +8,7 @@ in a target environment.
 For a local environment, you can use `pip` or `conda` or another preferred
 package manager to install the dependencies. Keep the `conda.yaml` in sync with
 the required dependencies. Otherwise, the robot might work when run locally,
-but not when run using Robocloud Worker.
+but not when run using Robocorp App.
 
 If you do not want to use conda at all and want to provide the execution
 environment yourself, you can delete the `conda.yaml` file.

--- a/google-image-search/entrypoints/INTRODUCTION.md
+++ b/google-image-search/entrypoints/INTRODUCTION.md
@@ -5,7 +5,7 @@ Define each entrypoint here as a script
 - These are the scripts you select for activity in Robocloud
 - Entrypoint scripts should not use any arguments
   > It is better to create scripts to contain the different argument variations
-  > so that selecting an entrypoint in Robocloud remains clear
+  > so that selecting an entrypoint in Robocorp Cloud remains clear
 
-This directory will be in PATH when the package is executed in Robocloud Worker
-or through Robocode CLI.
+This directory will be in PATH when the package is executed in Robocorp App
+or through Robocorp CLI.

--- a/google-image-search/temp/INTRODUCTION.md
+++ b/google-image-search/temp/INTRODUCTION.md
@@ -6,4 +6,4 @@ included in the package. By default, this directory is in .gitignore file.
 Robocode local run uses this directory as a working directory by default.
 
 If you remove this directory from the activity directory structure, you must
-provide the `--workarea` argument to Robocode CLI run command.
+provide the `--workarea` argument to Robocorp CLI run command.

--- a/robotsparebin-complete/README.md
+++ b/robotsparebin-complete/README.md
@@ -4,11 +4,11 @@ This activity is the finish point of Robocorp's Beginners course on [Robohub](ht
 
 Check the `robotsparebin-intranet-starter` activity for the initial version of the robot.
 
-## Executing with Robocode Lab
+## Executing with Robocorp Lab
 
-You can choose to run the activity in Robocode Lab in two different modes, using the _Run activity_ functionality or in _Notebook mode_.
+You can choose to run the activity in Robocorp Lab in two different modes, using the _Run activity_ functionality or in _Notebook mode_.
 
-> Visit Robohub to learn more about [running your activities in Robocode Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
+> Visit Robohub to learn more about [running your activities in Robocorp Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
 
 ### Running with Run Activity
 
@@ -21,6 +21,6 @@ Navigate to the `tasks` directory and double-click the `robot.robot` file to ope
 
 Click the `>>` icon or press `Ctrl+Shift+Enter` (Windows) or `Shift-Command-Enter` (macOS) and click `Restart` to run the robot.
 
-> You can also find the run command from the menu on the top of Robocode Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
+> You can also find the run command from the menu on the top of Robocorp Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
 
 > In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/) for more information.

--- a/robotsparebin-complete/config/INTRODUCTION.md
+++ b/robotsparebin-complete/config/INTRODUCTION.md
@@ -8,7 +8,7 @@ in a target environment.
 For a local environment, you can use `pip` or `conda` or another preferred
 package manager to install the dependencies. Keep the `conda.yaml` in sync with
 the required dependencies. Otherwise, the robot might work when run locally,
-but not when run using Robocloud Worker.
+but not when run using Robocorp App.
 
 If you do not want to use conda at all and want to provide the execution
 environment yourself, you can delete the `conda.yaml` file.

--- a/robotsparebin-complete/entrypoints/INTRODUCTION.md
+++ b/robotsparebin-complete/entrypoints/INTRODUCTION.md
@@ -5,7 +5,7 @@ Define each entrypoint here as a script
 - These are the scripts you select for activity in Robocloud
 - Entrypoint scripts should not use any arguments
   > It is better to create scripts to contain the different argument variations
-  > so that selecting an entrypoint in Robocloud remains clear
+  > so that selecting an entrypoint in Robocorp Cloud remains clear
 
-This directory will be in PATH when the package is executed in Robocloud Worker
-or through Robocode CLI.
+This directory will be in PATH when the package is executed in Robocorp App
+or through Robocorp CLI.

--- a/robotsparebin-complete/temp/INTRODUCTION.md
+++ b/robotsparebin-complete/temp/INTRODUCTION.md
@@ -6,4 +6,4 @@ included in the package. By default, this directory is in .gitignore file.
 Robocode local run uses this directory as a working directory by default.
 
 If you remove this directory from the activity directory structure, you must
-provide the `--workarea` argument to Robocode CLI run command.
+provide the `--workarea` argument to Robocorp CLI run command.

--- a/robotsparebin-starter/README.md
+++ b/robotsparebin-starter/README.md
@@ -4,11 +4,11 @@ This activity is the starting point of Robocorp's Beginners course on [Robohub](
 
 Check the `robotsparebin-intranet-complete` activity for the finished version of the robot.
 
-## Executing with Robocode Lab
+## Executing with Robocorp Lab
 
-You can choose to run the activity in Robocode Lab in two different modes, using the _Run activity_ functionality or in _Notebook mode_.
+You can choose to run the activity in Robocorp Lab in two different modes, using the _Run activity_ functionality or in _Notebook mode_.
 
-> Visit Robohub to learn more about [running your activities in Robocode Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
+> Visit Robohub to learn more about [running your activities in Robocorp Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
 
 ### Running with Run Activity
 
@@ -21,6 +21,6 @@ Navigate to the `tasks` directory and double-click the `robot.robot` file to ope
 
 Click the `>>` icon or press `Ctrl+Shift+Enter` (Windows) or `Shift-Command-Enter` (macOS) and click `Restart` to run the robot.
 
-> You can also find the run command from the menu on the top of Robocode Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
+> You can also find the run command from the menu on the top of Robocorp Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
 
 > In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/) for more information.

--- a/robotsparebin-starter/config/INTRODUCTION.md
+++ b/robotsparebin-starter/config/INTRODUCTION.md
@@ -8,7 +8,7 @@ in a target environment.
 For a local environment, you can use `pip` or `conda` or another preferred
 package manager to install the dependencies. Keep the `conda.yaml` in sync with
 the required dependencies. Otherwise, the robot might work when run locally,
-but not when run using Robocloud Worker.
+but not when run using Robocorp App.
 
 If you do not want to use conda at all and want to provide the execution
 environment yourself, you can delete the `conda.yaml` file.

--- a/robotsparebin-starter/entrypoints/INTRODUCTION.md
+++ b/robotsparebin-starter/entrypoints/INTRODUCTION.md
@@ -5,7 +5,7 @@ Define each entrypoint here as a script
 - These are the scripts you select for activity in Robocloud
 - Entrypoint scripts should not use any arguments
   > It is better to create scripts to contain the different argument variations
-  > so that selecting an entrypoint in Robocloud remains clear
+  > so that selecting an entrypoint in Robocorp Cloud remains clear
 
-This directory will be in PATH when the package is executed in Robocloud Worker
-or through Robocode CLI.
+This directory will be in PATH when the package is executed in Robocorp App
+or through Robocorp CLI.

--- a/robotsparebin-starter/temp/INTRODUCTION.md
+++ b/robotsparebin-starter/temp/INTRODUCTION.md
@@ -6,4 +6,4 @@ included in the package. By default, this directory is in .gitignore file.
 Robocode local run uses this directory as a working directory by default.
 
 If you remove this directory from the activity directory structure, you must
-provide the `--workarea` argument to Robocode CLI run command.
+provide the `--workarea` argument to Robocorp CLI run command.

--- a/rpa-form-challenge/README.md
+++ b/rpa-form-challenge/README.md
@@ -16,13 +16,13 @@ More in detail, when run, this robot will:
 
 You can find more details and a full explanation of the code on Robohub: https://hub.robocorp.com/knowledge-base/tutorials/rpa-form-challenge-tutorial/
 
-## Executing with Robocode Lab
+## Executing with Robocorp Lab
 
-Robocode Lab will take care of setting up the environment for you, so you do not need to run additional installation commands.
+Robocorp Lab will take care of setting up the environment for you, so you do not need to run additional installation commands.
 
-You can choose to run the activity in Robocode Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
+You can choose to run the activity in Robocorp Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
 
-> Visit Robohub to learn more about [running your activities in Robocode Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
+> Visit Robohub to learn more about [running your activities in Robocorp Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
 
 ### Running with Activity Run
 
@@ -35,11 +35,11 @@ Navigate to the `tasks` directory and double-click the `robot.robot` file to ope
 
 Click the `>>` icon or press `Ctrl+Shift+Enter` (Windows) or `Shift-Command-Enter` (macOS) and click `Restart` to run the robot.
 
-> You can also find the run command from the menu on the top of Robocode Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
+> You can also find the run command from the menu on the top of Robocorp Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
 
 > In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/) for more information.
 
-## Executing with Robocode CLI
+## Executing with Robocorp CLI
 
 > Assumes `robocode` is installed. Install with `pip install robocode`.
 

--- a/rpa-form-challenge/config/INTRODUCTION.md
+++ b/rpa-form-challenge/config/INTRODUCTION.md
@@ -8,7 +8,7 @@ in a target environment.
 For a local environment, you can use `pip` or `conda` or another preferred
 package manager to install the dependencies. Keep the `conda.yaml` in sync with
 the required dependencies. Otherwise, the robot might work when run locally,
-but not when run using Robocloud Worker.
+but not when run using Robocorp App.
 
 If you do not want to use conda at all and want to provide the execution
 environment yourself, you can delete the `conda.yaml` file.

--- a/rpa-form-challenge/entrypoints/INTRODUCTION.md
+++ b/rpa-form-challenge/entrypoints/INTRODUCTION.md
@@ -5,7 +5,7 @@ Define each entrypoint here as a script
 - These are the scripts you select for activity in Robocloud
 - Entrypoint scripts should not use any arguments
   > It is better to create scripts to contain the different argument variations
-  > so that selecting an entrypoint in Robocloud remains clear
+  > so that selecting an entrypoint in Robocorp Cloud remains clear
 
-This directory will be in PATH when the package is executed in Robocloud Worker
-or through Robocode CLI.
+This directory will be in PATH when the package is executed in Robocorp App
+or through Robocorp CLI.

--- a/rpa-form-challenge/temp/INTRODUCTION.md
+++ b/rpa-form-challenge/temp/INTRODUCTION.md
@@ -6,4 +6,4 @@ included in the package. By default, this directory is in .gitignore file.
 Robocode local run uses this directory as a working directory by default.
 
 If you remove this directory from the activity directory structure, you must
-provide the `--workarea` argument to Robocode CLI run command.
+provide the `--workarea` argument to Robocorp CLI run command.

--- a/simple-web-scraper/README.md
+++ b/simple-web-scraper/README.md
@@ -12,7 +12,7 @@ Install Python package dependencies:
 pip install rpaframework
 ```
 
-## Executing with Robocode CLI
+## Executing with Robocorp CLI
 
 > Assumes `robocode` is installed. Install with `pip install robocode`.
 
@@ -36,13 +36,13 @@ macOS / Linux:
 robo run entrypoint.sh
 ```
 
-## Executing with Robocode Lab
+## Executing with Robocorp Lab
 
-Robocode Lab will take care of setting up the environment for you, so you do not need to run additional installation commands.
+Robocorp Lab will take care of setting up the environment for you, so you do not need to run additional installation commands.
 
-You can choose to run the activity in Robocode Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
+You can choose to run the activity in Robocorp Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
 
-> Visit Robohub to learn more about [running your activities in Robocode Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
+> Visit Robohub to learn more about [running your activities in Robocorp Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
 
 ### Running with Activity Run
 
@@ -55,6 +55,6 @@ Navigate to the `tasks` directory and double-click the `robot.robot` file to ope
 
 Click the `>>` icon or press `Ctrl+Shift+Enter` (Windows) or `Shift-Command-Enter` (macOS) and click `Restart` to run the robot.
 
-> You can also find the run command from the menu on the top of Robocode Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
+> You can also find the run command from the menu on the top of Robocorp Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
 
 > In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/) for more information.

--- a/simple-web-scraper/config/README.md
+++ b/simple-web-scraper/config/README.md
@@ -8,7 +8,7 @@ in a target environment.
 For a local environment, you can use `pip` or `conda` or another preferred
 package manager to install the dependencies. Keep the `conda.yaml` in sync with
 the required dependencies. Otherwise, the robot might work when run locally,
-but not when run using Robocloud Worker.
+but not when run using Robocorp App.
 
 If you do not want to use conda at all and want to provide the execution
 environment yourself, you can delete the `conda.yaml` file.

--- a/simple-web-scraper/entrypoints/INTRODUCTION.md
+++ b/simple-web-scraper/entrypoints/INTRODUCTION.md
@@ -5,7 +5,7 @@ Define each entrypoint here as a script
 - These are the scripts you select for activity in Robocloud
 - Entrypoint scripts should not use any arguments
   > It is better to create scripts to contain the different argument variations
-  > so that selecting an entrypoint in Robocloud remains clear
+  > so that selecting an entrypoint in Robocorp Cloud remains clear
 
-This directory will be in PATH when the bundle is executed in Robocloud Worker
-or through Robocode CLI.
+This directory will be in PATH when the bundle is executed in Robocorp App
+or through Robocorp CLI.

--- a/simple-web-scraper/temp/INTRODUCTION.md
+++ b/simple-web-scraper/temp/INTRODUCTION.md
@@ -6,4 +6,4 @@ included in the package. By default, this directory is in .gitignore file.
 Robocode local run uses this directory as a working directory by default.
 
 If you remove this directory from the activity directory structure, you must
-provide the `--workarea` argument to Robocode CLI run command.
+provide the `--workarea` argument to Robocorp CLI run command.

--- a/web-store-order-processor/README.md
+++ b/web-store-order-processor/README.md
@@ -45,7 +45,7 @@ Configure your vault using the UI. The name of the vault should be `swaglabs`.
 Provide the user name and the password as key-value pairs (see the vault file
 for the exact naming).
 
-## Executing with Robocode CLI
+## Executing with Robocorp CLI
 
 > Assumes `robocode` is installed. Install with `pip install robocode`.
 
@@ -69,13 +69,13 @@ macOS / Linux:
 robo run entrypoint.sh -v devdata/env.json
 ```
 
-## Executing with Robocode Lab
+## Executing with Robocorp Lab
 
-Robocode Lab will take care of setting up the environment for you, so you do not need to run additional installation commands.
+Robocorp Lab will take care of setting up the environment for you, so you do not need to run additional installation commands.
 
-You can choose to run the activity in Robocode Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
+You can choose to run the activity in Robocorp Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
 
-> Visit Robohub to learn more about [running your activities in Robocode Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
+> Visit Robohub to learn more about [running your activities in Robocorp Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
 
 ### Running with Activity Run
 
@@ -88,6 +88,6 @@ Navigate to the `tasks` directory and double-click the `robot.robot` file to ope
 
 Click the `>>` icon or press `Ctrl+Shift+Enter` (Windows) or `Shift-Command-Enter` (macOS) and click `Restart` to run the robot.
 
-> You can also find the run command from the menu on the top of Robocode Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
+> You can also find the run command from the menu on the top of Robocorp Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
 
 > In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/) for more information.

--- a/web-store-order-processor/bin/INTRODUCTION.md
+++ b/web-store-order-processor/bin/INTRODUCTION.md
@@ -3,5 +3,5 @@
 If you need your package to have standalone binaries or executables, you
 should add them to this directory.
 
-This directory will be in PATH when the package is executed in Robocloud Worker
-or through Robocode CLI.
+This directory will be in PATH when the package is executed in Robocorp App
+or through Robocorp CLI.

--- a/web-store-order-processor/config/README.md
+++ b/web-store-order-processor/config/README.md
@@ -8,7 +8,7 @@ in a target environment.
 For a local environment, you can use `pip` or `conda` or another preferred
 package manager to install the dependencies. Keep the `conda.yaml` in sync with
 the required dependencies. Otherwise, the robot might work when run locally,
-but not when run using Robocloud Worker.
+but not when run using Robocorp App.
 
 If you do not want to use conda at all and want to provide the execution
 environment yourself, you can delete the `conda.yaml` file.

--- a/web-store-order-processor/devdata/INTRODUCTION.md
+++ b/web-store-order-processor/devdata/INTRODUCTION.md
@@ -2,11 +2,11 @@
 
 This directory should contain local development data.
 
-This data should not be used in actual Robocloud Worker run but can be
+This data should not be used in actual Robocorp App run but can be
 used when you are building and debugging your entrypoints and activities.
 
 ## What to put here?
 
 - Local work item data
 - Local environment variables (in JSON format)
-- Local custom data files (*.csv, etc.)
+- Local custom data files (\*.csv, etc.)

--- a/web-store-order-processor/entrypoints/INTRODUCTION.md
+++ b/web-store-order-processor/entrypoints/INTRODUCTION.md
@@ -5,7 +5,7 @@ Define each entrypoint here as a script
 - These are the scripts you select for activity in Robocloud
 - Entrypoint scripts should not use any arguments
   > It is better to create scripts to contain the different argument variations
-  > so that selecting an entrypoint in Robocloud remains clear
+  > so that selecting an entrypoint in Robocorp Cloud remains clear
 
-This directory will be in PATH when the package is executed in Robocloud Worker
-or through Robocode CLI.
+This directory will be in PATH when the package is executed in Robocorp App
+or through Robocorp CLI.

--- a/web-store-order-processor/temp/INTRODUCTION.md
+++ b/web-store-order-processor/temp/INTRODUCTION.md
@@ -6,4 +6,4 @@ included in the package. By default, this directory is in .gitignore file.
 Robocode local run uses this directory as a working directory by default.
 
 If you remove this directory from the activity directory structure, you must
-provide the `--workarea` argument to Robocode CLI run command.
+provide the `--workarea` argument to Robocorp CLI run command.

--- a/work-item-to-pdf/README.md
+++ b/work-item-to-pdf/README.md
@@ -20,7 +20,7 @@ pip install rpaframework robotframework-archivelibrary
 
 ## Setting up the Robocloud.Items library for local use
 
-When executing our robot in a cloud environment like [Robocloud](https://cloud.robocorp.com), the `RPA.Robocloud.Items` library will store the work item in the cloud environment, sharing its contents between activities defined in the same process, without any configuration needed.
+When executing our robot in a cloud environment like [Robocorp Cloud](https://cloud.robocorp.com), the `RPA.Robocloud.Items` library will store the work item in the cloud environment, sharing its contents between activities defined in the same process, without any configuration needed.
 
 When developing our activity and running it locally, however, we want the library to store the data in a JSON file, and provide the required parameters to simulate the cloud environment. You can learn more about the internals of the `RPA.Robocloud.Items` library [here](https://hub.robocorp.com/resources/libraries/rpaframework-Robocloud-Items/).
 
@@ -29,9 +29,9 @@ When developing our activity and running it locally, however, we want the librar
 Edit the `RPA_WORKITEMS_PATH` variable to point to the `items.json` file on your filesystem. On macOS / Linux, use normal file paths,
 for example, `/tmp/items.json`. On Windows 10, you need to escape the path, for example, `C:\\Users\\User\\items.json`.
 
-> By pointing to the same file that we used in the first activity and by specifying the same workspace and work item id, we are now effectively sharing data between the two activities. This way, we are simulating what happens in [Robocloud](https://cloud.robocorp.com) when two activities are added to the same process.
+> By pointing to the same file that we used in the first activity and by specifying the same workspace and work item id, we are now effectively sharing data between the two activities. This way, we are simulating what happens in [Robocorp Cloud](https://cloud.robocorp.com) when two activities are added to the same process.
 
-## Executing with Robocode CLI
+## Executing with Robocorp CLI
 
 > Assumes `robocode` is installed. Install with `pip install robocode`.
 
@@ -55,13 +55,13 @@ macOS / Linux:
 robo run entrypoint.sh -v devdata/env.json
 ```
 
-## Executing with Robocode Lab
+## Executing with Robocorp Lab
 
-Robocode Lab will take care of setting up the environment for you, so you do not need to run additional installation commands.
+Robocorp Lab will take care of setting up the environment for you, so you do not need to run additional installation commands.
 
-You can choose to run the activity in Robocode Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
+You can choose to run the activity in Robocorp Lab in two different modes, using the _Activity run_ functionality or in _Notebook mode_.
 
-> Visit Robohub to learn more about [running your activities in Robocode Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
+> Visit Robohub to learn more about [running your activities in Robocorp Lab](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/).
 
 ### Running with Activity Run
 
@@ -74,12 +74,12 @@ Navigate to the `tasks` directory and double-click the `robot.robot` file to ope
 
 Click the `>>` icon or press `Ctrl+Shift+Enter` (Windows) or `Shift-Command-Enter` (macOS) and click `Restart` to run the robot.
 
-> You can also find the run command from the menu on the top of Robocode Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
+> You can also find the run command from the menu on the top of Robocorp Lab screen, by selecting `Run` -> `Restart Kernel and Run All Cells...`.
 
 > In Notebook mode you can also run only part of an activity step by step. Check [this article on Robohub](https://hub.robocorp.com/knowledge-base/articles/running-robots-in-robocode-lab/) for more information.
 
 ## Expected results of the activity
 
-After you run the robot, you will find a zip archive `PDFs.zip` file in the `temp/robocode/work-item-to-pdf/output` directory, or the `output` directory if executing the example activity in Robocode Lab in notebook mode.
+After you run the robot, you will find a zip archive `PDFs.zip` file in the `temp/robocode/work-item-to-pdf/output` directory, or the `output` directory if executing the example activity in Robocorp Lab in notebook mode.
 
 Extract it and you will see the PDF invitations according to the data in the Excel file.

--- a/work-item-to-pdf/bin/INTRODUCTION.md
+++ b/work-item-to-pdf/bin/INTRODUCTION.md
@@ -3,5 +3,5 @@
 If you need your package to have standalone binaries or executables, you
 should add them to this directory.
 
-This directory will be in PATH when the package is executed in Robocloud Worker
-or through Robocode CLI.
+This directory will be in PATH when the package is executed in Robocorp App
+or through Robocorp CLI.

--- a/work-item-to-pdf/config/INTRODUCTION.md
+++ b/work-item-to-pdf/config/INTRODUCTION.md
@@ -8,7 +8,7 @@ in a target environment.
 For a local environment, you can use `pip` or `conda` or another preferred
 package manager to install the dependencies. Keep the `conda.yaml` in sync with
 the required dependencies. Otherwise, the robot might work when run locally,
-but not when run using Robocloud Worker.
+but not when run using Robocorp App.
 
 If you do not want to use conda at all and want to provide the execution
 environment yourself, you can delete the `conda.yaml` file.

--- a/work-item-to-pdf/devdata/INTRODUCTION.md
+++ b/work-item-to-pdf/devdata/INTRODUCTION.md
@@ -2,11 +2,11 @@
 
 This directory should contain local development data.
 
-This data should not be used in actual Robocloud Worker run but can be
+This data should not be used in actual Robocorp App run but can be
 used when you are building and debugging your entrypoints and activities.
 
 ## What to put here?
 
 - Local work item data
 - Local environment variables (in JSON format)
-- Local custom data files (*.csv, etc.)
+- Local custom data files (\*.csv, etc.)

--- a/work-item-to-pdf/entrypoints/INTRODUCTION.md
+++ b/work-item-to-pdf/entrypoints/INTRODUCTION.md
@@ -5,7 +5,7 @@ Define each entrypoint here as a script
 - These are the scripts you select for activity in Robocloud
 - Entrypoint scripts should not use any arguments
   > It is better to create scripts to contain the different argument variations
-  > so that selecting an entrypoint in Robocloud remains clear
+  > so that selecting an entrypoint in Robocorp Cloud remains clear
 
-This directory will be in PATH when the package is executed in Robocloud Worker
-or through Robocode CLI.
+This directory will be in PATH when the package is executed in Robocorp App
+or through Robocorp CLI.

--- a/work-item-to-pdf/temp/INTRODUCTION.md
+++ b/work-item-to-pdf/temp/INTRODUCTION.md
@@ -6,4 +6,4 @@ included in the package. By default, this directory is in .gitignore file.
 Robocode local run uses this directory as a working directory by default.
 
 If you remove this directory from the activity directory structure, you must
-provide the `--workarea` argument to Robocode CLI run command.
+provide the `--workarea` argument to Robocorp CLI run command.


### PR DESCRIPTION
Goes together with https://github.com/robocorp/robohub-v2/pull/275 

Apply new naming for products mentioned in readme files.

Robocode Lab -> Robocorp Lab
Robocloud   -> Robocorp Cloud
Robocloud worker -> Robocorp App
Robocode CLI -> Robocorp CLI