### PR TITLE
Feature/update gitignore for virtual documents folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 **/.DS_STORE
 *.zip
 .vscode
+.virtual_documents/
+*/.virtual_documents/*

--- a/excel-to-work-item/.gitignore
+++ b/excel-to-work-item/.gitignore
@@ -9,3 +9,5 @@ temp/
 .DS_Store
 *.pyc
 *.zip
+.virtual_documents/
+*/.virtual_documents/*

--- a/google-image-search/.gitignore
+++ b/google-image-search/.gitignore
@@ -9,3 +9,5 @@ temp/
 .DS_Store
 *.pyc
 *.zip
+.virtual_documents/
+*/.virtual_documents/*

--- a/my-first-robot/.gitignore
+++ b/my-first-robot/.gitignore
@@ -1,2 +1,3 @@
 .ipynb_checkpoints
-.virtual_documents
+.virtual_documents/
+*/.virtual_documents/*

--- a/robotsparebin-complete/.gitignore
+++ b/robotsparebin-complete/.gitignore
@@ -12,3 +12,5 @@ temp/
 *.pdf
 *.template
 *.xlsx
+.virtual_documents/
+*/.virtual_documents/*

--- a/robotsparebin-starter/.gitignore
+++ b/robotsparebin-starter/.gitignore
@@ -5,6 +5,8 @@ temp/
 .idea/
 .ipynb_checkpoints/
 */.ipynb_checkpoints/*
+.virtual_documents/
+*/.virtual_documents/*
 .vscode
 .DS_Store
 *.pyc
@@ -12,3 +14,5 @@ temp/
 *.pdf
 *.template
 *.xlsx
+.virtual_documents/
+*/.virtual_documents/*

--- a/robotsparebin-starter/.gitignore
+++ b/robotsparebin-starter/.gitignore
@@ -5,8 +5,6 @@ temp/
 .idea/
 .ipynb_checkpoints/
 */.ipynb_checkpoints/*
-.virtual_documents/
-*/.virtual_documents/*
 .vscode
 .DS_Store
 *.pyc

--- a/rpa-form-challenge/.gitignore
+++ b/rpa-form-challenge/.gitignore
@@ -10,3 +10,5 @@ temp/
 *.pyc
 *.zip
 *.xlsx
+.virtual_documents/
+*/.virtual_documents/*

--- a/simple-web-scraper/.gitignore
+++ b/simple-web-scraper/.gitignore
@@ -9,3 +9,5 @@ temp/
 .DS_Store
 *.pyc
 *.zip
+.virtual_documents/
+*/.virtual_documents/*

--- a/web-store-order-processor/.gitignore
+++ b/web-store-order-processor/.gitignore
@@ -9,3 +9,5 @@ temp/
 .DS_Store
 *.pyc
 *.zip
+.virtual_documents/
+*/.virtual_documents/*

--- a/work-item-to-pdf/.gitignore
+++ b/work-item-to-pdf/.gitignore
@@ -9,3 +9,5 @@ temp/
 .DS_Store
 *.pyc
 *.zip
+.virtual_documents/
+*/.virtual_documents/*


### PR DESCRIPTION
Adds the `.virtual_documents` folder to gitignore to all examples.

This is a folder that gets created by the LSP extension in lab.