### PR TITLE
Fix keyword name in explanation text in my first robot

### DIFF
--- a/my-first-robot/robot.robot
+++ b/my-first-robot/robot.robot
@@ -37,7 +37,7 @@ Task Teardown     Close All Browsers
 
 # ### Step 2. Editing a cell
 #
-# In the next cell we declare a new keyword called "Say Hello", which prints a simple greeting.
+# In the next cell we declare a new keyword called "Show Greeting", which prints a simple greeting.
 #
 
 *** Keyword ***


### PR DESCRIPTION
We changed the name of the "Say hello" keyword to "Show Greeting", but one phrase in markdown still had "Say Hello". This fixes it.