### PR TITLE
Fix path of output folder in robotsparebin-complete

### DIFF
--- a/robotsparebin-complete/tasks.robot
+++ b/robotsparebin-complete/tasks.robot
@@ -55,9 +55,9 @@ Collect The Results
 Export The Table As A PDF
     Wait Until Element Is Visible    id:sales-results
     ${sales_results_html}=    Get Element Attribute    id:sales-results    outerHTML
-    ${directory_exists}=    Does Directory Exist    ${CURDIR}${/}..${/}output
-    Run Keyword If    ${directory_exists}==False    Create directory    ${CURDIR}${/}..${/}output
-    Html To Pdf    ${sales_results_html}    ${CURDIR}${/}..${/}output${/}sales_results.pdf
+    ${directory_exists}=    Does Directory Exist    ${CURDIR}${/}output
+    Run Keyword If    ${directory_exists}==False    Create directory    ${CURDIR}${/}output
+    Html To Pdf    ${sales_results_html}    ${CURDIR}${/}output${/}sales_results.pdf
 
 *** Keywords ***
 Log Out And Close The Browser


### PR DESCRIPTION
Now that the robot has been reorganized into a flatter structure, the path for the output artifacts needs to be updated as well.