### PR TITLE
Python robot example: do not use input as a variable name

### DIFF
--- a/python-robot/tasks.py
+++ b/python-robot/tasks.py
@@ -11,9 +11,9 @@ def open_the_website(url: str):
 
 
 def search_for(term: str):
-    input = "css:input"
-    browser.input_text(input, term)
-    browser.press_keys(input, "ENTER")
+    input_field = "css:input"
+    browser.input_text(input_field, term)
+    browser.press_keys(input_field, "ENTER")
 
 
 def store_screenshot(filename: str):


### PR DESCRIPTION
as this can cause conflicts with the `input()` built-in function.